### PR TITLE
Switch to ppxlib

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -23,9 +23,9 @@
   (dune (and (>= 2) (< 3)))
   (ocaml (and (>= 4.10.0) (< 4.11.0)))
 
-  (js_of_ocaml (and (>= 3.7.0) (< 3.8.0)))
-  (gen_js_api (and (>= 1.0.7) (< 1.1.0)))
-  (ocaml-migrate-parsetree (and (>= 1.7.3) (< 2.0.0)))
+  (js_of_ocaml (and (>= 3.8.0) (< 3.11.0)))
+  (gen_js_api (and (>= 1.0.8) (< 1.1.0)))
+  (ppxlib (>= 0.23.0))
 
   ;; Test dependencies
   (webtest :with-test)

--- a/jsoo-react.opam
+++ b/jsoo-react.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/reason-in-barcelona/jsoo-react"
 bug-reports: "https://github.com/reason-in-barcelona/jsoo-react/issues"
 depends: [
   "dune" {>= "2.7" & >= "2" & < "3"}
-  "ocaml" {>= "4.10.0" & < "4.11.0"}
+  "ocaml" {>= "4.10.0" & < "4.14.0"}
   "js_of_ocaml" {>= "3.8.0" & < "3.11.0"}
   "gen_js_api" {>= "1.0.8" & < "1.1.0"}
   "ppxlib" {>= "0.23.0"}

--- a/jsoo-react.opam
+++ b/jsoo-react.opam
@@ -9,9 +9,9 @@ bug-reports: "https://github.com/reason-in-barcelona/jsoo-react/issues"
 depends: [
   "dune" {>= "2.7" & >= "2" & < "3"}
   "ocaml" {>= "4.10.0" & < "4.11.0"}
-  "js_of_ocaml" {>= "3.7.0" & < "3.8.0"}
-  "gen_js_api" {>= "1.0.7" & < "1.1.0"}
-  "ocaml-migrate-parsetree" {>= "1.7.3" & < "2.0.0"}
+  "js_of_ocaml" {>= "3.8.0" & < "3.11.0"}
+  "gen_js_api" {>= "1.0.8" & < "1.1.0"}
+  "ppxlib" {>= "0.23.0"}
   "webtest" {with-test}
   "webtest-js" {with-test}
   "js_of_ocaml-ppx" {with-test}

--- a/ppx/dune
+++ b/ppx/dune
@@ -6,7 +6,7 @@
 (library
  (name jsoo_react_ppx)
  (public_name jsoo-react.ppx)
- (libraries compiler-libs.common ocaml-migrate-parsetree)
+ (libraries compiler-libs.common ppxlib ppxlib.astlib)
  (preprocess
   (pps ppxlib.metaquot))
  (kind ppx_rewriter))

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -19,13 +19,9 @@
    `React.createFragment([foo])`
  *)
 
-open Migrate_parsetree
-open OCaml_410.Ast
+module Ocaml_location = Location
+open Ppxlib
 open Ast_helper
-open Ast_mapper
-open Asttypes
-open Parsetree
-open Longident
 
 let rec find_opt p = function
   | [] ->
@@ -55,7 +51,7 @@ let argIsKeyRef = function
       false
 
 let constantString ~loc str =
-  Ast_helper.Exp.constant ~loc (Pconst_string (str, None))
+  Ast_helper.Exp.constant ~loc (Const.string str)
 
 let safeTypeFromValue valueStr =
   let valueStr = getLabel valueStr in
@@ -97,9 +93,9 @@ let transformChildrenIfListUpper ~loc ~mapper theList =
       | accum ->
           ListLiteral (revAstList ~loc accum) )
     | [%expr [%e? v] :: [%e? acc]] ->
-        transformChildren_ acc [%expr [%e mapper.expr mapper v] :: [%e accum]]
+        transformChildren_ acc [%expr [%e mapper#expression v] :: [%e accum]]
     | notAList ->
-        Exact (mapper.expr mapper notAList)
+        Exact (mapper#expression notAList)
   in
   transformChildren_ theList [%expr []]
 
@@ -110,9 +106,9 @@ let transformChildrenIfList ~loc ~mapper theList =
     | [%expr []] ->
         revAstList ~loc accum
     | [%expr [%e? v] :: [%e? acc]] ->
-        transformChildren_ acc [%expr [%e mapper.expr mapper v] :: [%e accum]]
+        transformChildren_ acc [%expr [%e mapper#expression v] :: [%e accum]]
     | notAList ->
-        mapper.expr mapper notAList
+        mapper#expression notAList
   in
   transformChildren_ theList [%expr []]
 
@@ -148,7 +144,7 @@ let extractChildren ?(removeLastPositionUnit = false) ~loc propsAndChildren =
 
 let unerasableIgnore loc =
   { attr_name= {txt= "warning"; loc}
-  ; attr_payload= PStr [Str.eval (Exp.constant (Pconst_string ("-16", None)))]
+  ; attr_payload= PStr [Str.eval (Exp.constant (Const.string "-16"))]
   ; attr_loc= loc }
 
 let merlinFocus =
@@ -197,7 +193,7 @@ let getPropsNameValue _acc (loc, exp) =
       raise
         (Invalid_argument
            ( "react.component only accepts props as an option, given: "
-           ^ Longident.last txt ))
+           ^ Longident.last_exn txt ))
 
 (* Lookup the `props` record or string as part of [@react.component] and store the name for use when rewriting *)
 let getPropsAttr payload =
@@ -231,7 +227,7 @@ let filenameFromLoc (pstr_loc : Location.t) =
   let fileName =
     match pstr_loc.loc_start.pos_fname with
     | "" ->
-        !Location.input_name
+        !Ocaml_location.input_name
     | fileName ->
         fileName
   in
@@ -363,11 +359,11 @@ let makeJsObj ~loc namedArgListWithKeyAndRef =
       match l = "key" with
       | true ->
           [%expr
-            [%e Exp.constant ~loc (Pconst_string (l, None))]
+            [%e Exp.constant ~loc (Const.string l)]
             , inject (Js_of_ocaml.Js.string [%e raw])]
       | false ->
           [%expr
-            [%e Exp.constant ~loc (Pconst_string (l, None))], inject [%e raw]]
+            [%e Exp.constant ~loc (Const.string l)], inject [%e raw]]
     in
     match isOptional label with
     | true ->
@@ -434,7 +430,7 @@ let jsxMapper () =
     let recursivelyTransformedArgsForMake =
       argsForMake
       |> List.map (fun (label, expression) ->
-             (label, mapper.expr mapper expression))
+             (label, mapper#expression expression))
     in
     let childrenArg = ref None in
     let args =
@@ -528,7 +524,7 @@ let jsxMapper () =
                  {loc; txt= Ldot (Ldot (Lident "React", "Dom"), "domProps")})
               ( nonEmptyProps
               |> List.map (fun (label, expression) ->
-                     (label, mapper.expr mapper expression)) )
+                     (label, mapper#expression expression)) )
           in
           [ (* "div" *)
             (nolabel, componentNameExpr)
@@ -546,7 +542,7 @@ let jsxMapper () =
       args
   in
   let rec recursivelyTransformNamedArgsForMake mapper expr list =
-    let expr = mapper.expr mapper expr in
+    let expr = mapper#expression expr in
     match expr.pexp_desc with
     (* TODO: make this show up with a loc. *)
     | Pexp_fun (Labelled "key", _, _, _) | Pexp_fun (Optional "key", _, _, _) ->
@@ -571,18 +567,16 @@ let jsxMapper () =
                 let currentType =
                   match ptyp_desc with
                   | Ptyp_constr ({txt}, []) ->
-                      String.concat "." (Longident.flatten txt)
+                      String.concat "." (Longident.flatten_exn txt)
                   | Ptyp_constr ({txt}, _innerTypeArgs) ->
-                      String.concat "." (Longident.flatten txt) ^ "(...)"
+                      String.concat "." (Longident.flatten_exn txt) ^ "(...)"
                   | _ ->
                       "..."
                 in
-                Location.prerr_warning pattern.ppat_loc
-                  (Preprocessor
-                     (Printf.sprintf
-                        "jsoo-react: optional argument annotations must have \
-                         explicit `option`. Did you mean `option(%s)=?`?"
-                        currentType)) )
+                Location.raise_errorf ~loc:pattern.ppat_loc
+                  "jsoo-react: optional argument annotations must have \
+                    explicit `option`. Did you mean `option(%s)=?`?"
+                  currentType )
           | _ ->
               ()
         in
@@ -983,7 +977,7 @@ let jsxMapper () =
                       Exp.ident ~loc {txt= Lident props.propsName; loc}
                     in
                     let labelStringConst =
-                      Exp.constant ~loc (Pconst_string (labelString, None))
+                      Exp.constant ~loc (Const.string labelString)
                     in
                     let send =
                       Exp.send ~loc
@@ -1216,79 +1210,80 @@ let jsxMapper () =
              "JSX: `createElement` should be preceeded by a simple, direct \
               module name.")
   in
-  let signature mapper signature =
-    default_mapper.signature mapper
-    @@ reactComponentSignatureTransform mapper signature
-  in
-  let structure mapper structure =
-    match structure with
-    | structures ->
-        default_mapper.structure mapper
-        @@ reactComponentTransform mapper structures
-  in
-  let expr mapper expression =
-    match expression with
-    (* Does the function application have the @JSX attribute? *)
-    | {pexp_desc= Pexp_apply (callExpression, callArguments); pexp_attributes}
-      -> (
-        let jsxAttribute, nonJSXAttributes =
-          List.partition
-            (fun attribute -> attribute.attr_name.txt = "JSX")
-            pexp_attributes
-        in
-        match (jsxAttribute, nonJSXAttributes) with
-        (* no JSX attribute *)
-        | [], _ ->
-            default_mapper.expr mapper expression
-        | _, nonJSXAttributes ->
-            transformJsxCall mapper callExpression callArguments
-              nonJSXAttributes )
-    (* is it a list with jsx attribute? Reason <>foo</> desugars to [@JSX][foo]*)
-    | { pexp_desc=
-          ( Pexp_construct
-              ({txt= Lident "::"; loc}, Some {pexp_desc= Pexp_tuple _})
-          | Pexp_construct ({txt= Lident "[]"; loc}, None) )
-      ; pexp_attributes } as listItems -> (
-        let jsxAttribute, nonJSXAttributes =
-          List.partition
-            (fun attribute -> attribute.attr_name.txt = "JSX")
-            pexp_attributes
-        in
-        match (jsxAttribute, nonJSXAttributes) with
-        (* no JSX attribute *)
-        | [], _ ->
-            default_mapper.expr mapper expression
-        | _, nonJSXAttributes ->
-            let callExpression = [%expr React.Fragment.createElement] in
-            transformJsxCall mapper callExpression
-              [(Labelled "children", listItems)]
-              nonJSXAttributes )
-    (* Delegate to the default mapper, a deep identity traversal *)
-    | e ->
-        default_mapper.expr mapper e
-  in
-  let module_binding mapper module_binding =
-    let _ =
-      match module_binding.pmb_name.txt with
-      | None ->
-          ()
-      | Some txt ->
-          nestedModules := txt :: !nestedModules
-    in
-    let mapped = default_mapper.module_binding mapper module_binding in
-    let _ = nestedModules := List.tl !nestedModules in
-    mapped
-  in
-  {default_mapper with structure; expr; signature; module_binding}
+  object (self)
+    inherit Ast_traverse.map as super
+
+    method! signature signature =
+      super#signature @@ reactComponentSignatureTransform self signature
+
+    method! structure structure =
+      match structure with
+      | structures ->
+          super#structure @@ reactComponentTransform self structures
+
+    method! expression expression =
+      match expression with
+      (* Does the function application have the @JSX attribute? *)
+      | {pexp_desc= Pexp_apply (callExpression, callArguments); pexp_attributes}
+        -> (
+          let jsxAttribute, nonJSXAttributes =
+            List.partition
+              (fun attribute -> attribute.attr_name.txt = "JSX")
+              pexp_attributes
+          in
+          match (jsxAttribute, nonJSXAttributes) with
+          (* no JSX attribute *)
+          | [], _ ->
+              super#expression expression
+          | _, nonJSXAttributes ->
+              transformJsxCall self callExpression callArguments
+                nonJSXAttributes )
+      (* is it a list with jsx attribute? Reason <>foo</> desugars to [@JSX][foo]*)
+      | { pexp_desc=
+            ( Pexp_construct
+                ({txt= Lident "::"; loc}, Some {pexp_desc= Pexp_tuple _})
+            | Pexp_construct ({txt= Lident "[]"; loc}, None) )
+        ; pexp_attributes } as listItems -> (
+          let jsxAttribute, nonJSXAttributes =
+            List.partition
+              (fun attribute -> attribute.attr_name.txt = "JSX")
+              pexp_attributes
+          in
+          match (jsxAttribute, nonJSXAttributes) with
+          (* no JSX attribute *)
+          | [], _ ->
+              super#expression expression
+          | _, nonJSXAttributes ->
+              let callExpression = [%expr React.Fragment.createElement] in
+              transformJsxCall self callExpression
+                [(Labelled "children", listItems)]
+                nonJSXAttributes )
+      (* Delegate to the default mapper, a deep identity traversal *)
+      | e ->
+          super#expression e
+
+    method! module_binding module_binding =
+      let _ =
+        match module_binding.pmb_name.txt with
+        | None ->
+            ()
+        | Some txt ->
+            nestedModules := txt :: !nestedModules
+      in
+      let mapped = super#module_binding module_binding in
+      let _ = nestedModules := List.tl !nestedModules in
+      mapped
+  end
 
 let rewrite_implementation (code : Parsetree.structure) : Parsetree.structure =
   let mapper = jsxMapper () in
-  mapper.structure mapper code
+  mapper#structure code
 
 let rewrite_signature (code : Parsetree.signature) : Parsetree.signature =
   let mapper = jsxMapper () in
-  mapper.signature mapper code
+  mapper#signature code
 
 let () =
-  Driver.register ~name:"jsoo-react-ppx" Migrate_parsetree.Versions.ocaml_410
-    (fun _config _cookies -> jsxMapper ())
+  Driver.register_transformation "jsoo-react-ppx"
+    ~impl:rewrite_implementation
+    ~intf:rewrite_signature

--- a/ppx/test/dune
+++ b/ppx/test/dune
@@ -1,6 +1,6 @@
 (executable
  (name main)
- (libraries reason ocaml-migrate-parsetree jsoo_react_ppx))
+ (libraries reason ppxlib jsoo_react_ppx))
 
 (rule
  (targets pp.result)

--- a/ppx/test/main.ml
+++ b/ppx/test/main.ml
@@ -1,4 +1,4 @@
-open Migrate_parsetree
+open Ppxlib
 
 (* To run as a standalone binary, run the registered drivers *)
-let () = Driver.run_main ()
+let () = Driver.standalone ()

--- a/ppx/test/pp.expected
+++ b/ppx/test/pp.expected
@@ -81,12 +81,10 @@ let make =
       < name: 'name option Js_of_ocaml.Js.readonly_prop   >  Js_of_ocaml.Js.t)
     =
     make
-      ?name:((fun (type res) ->
-                fun (type a0) ->
-                  fun (a0 : a0 Js_of_ocaml.Js.t) ->
-                    fun
-                      (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
-                      -> (Js_of_ocaml.Js.Unsafe.get a0 "name" : res))
+      ?name:(fun (type res) -> fun (type a0) ->
+               fun (a0 : a0 Js_of_ocaml.Js.t) ->
+                 fun (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
+                   -> (Js_of_ocaml.Js.Unsafe.get a0 "name" : res)
                (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#name)) in
   Test
 let makeProps
@@ -134,17 +132,15 @@ let make =
         Js_of_ocaml.Js.t)
     =
     make
-      ~b:((fun (type res) ->
-             fun (type a0) ->
-               fun (a0 : a0 Js_of_ocaml.Js.t) ->
-                 fun (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
-                   -> (Js_of_ocaml.Js.Unsafe.get a0 "b" : res))
+      ~b:(fun (type res) -> fun (type a0) ->
+            fun (a0 : a0 Js_of_ocaml.Js.t) ->
+              fun (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop) ->
+                (Js_of_ocaml.Js.Unsafe.get a0 "b" : res)
             (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#b))
-      ~a:((fun (type res) ->
-             fun (type a0) ->
-               fun (a0 : a0 Js_of_ocaml.Js.t) ->
-                 fun (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
-                   -> (Js_of_ocaml.Js.Unsafe.get a0 "a" : res))
+      ~a:(fun (type res) -> fun (type a0) ->
+            fun (a0 : a0 Js_of_ocaml.Js.t) ->
+              fun (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop) ->
+                (Js_of_ocaml.Js.Unsafe.get a0 "a" : res)
             (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#a)) () in
   Test
 module External =
@@ -234,21 +230,15 @@ module Bar =
             Js_of_ocaml.Js.t)
         =
         make
-          ~b:((fun (type res) ->
-                 fun (type a0) ->
-                   fun (a0 : a0 Js_of_ocaml.Js.t) ->
-                     fun
-                       (_ :
-                         a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
-                       -> (Js_of_ocaml.Js.Unsafe.get a0 "b" : res))
+          ~b:(fun (type res) -> fun (type a0) ->
+                fun (a0 : a0 Js_of_ocaml.Js.t) ->
+                  fun (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
+                    -> (Js_of_ocaml.Js.Unsafe.get a0 "b" : res)
                 (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#b))
-          ~a:((fun (type res) ->
-                 fun (type a0) ->
-                   fun (a0 : a0 Js_of_ocaml.Js.t) ->
-                     fun
-                       (_ :
-                         a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
-                       -> (Js_of_ocaml.Js.Unsafe.get a0 "a" : res))
+          ~a:(fun (type res) -> fun (type a0) ->
+                fun (a0 : a0 Js_of_ocaml.Js.t) ->
+                  fun (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
+                    -> (Js_of_ocaml.Js.Unsafe.get a0 "a" : res)
                 (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#a)) () in
       Test$Bar
     let componentProps
@@ -299,21 +289,15 @@ module Bar =
             Js_of_ocaml.Js.t)
         =
         component
-          ~b:((fun (type res) ->
-                 fun (type a0) ->
-                   fun (a0 : a0 Js_of_ocaml.Js.t) ->
-                     fun
-                       (_ :
-                         a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
-                       -> (Js_of_ocaml.Js.Unsafe.get a0 "b" : res))
+          ~b:(fun (type res) -> fun (type a0) ->
+                fun (a0 : a0 Js_of_ocaml.Js.t) ->
+                  fun (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
+                    -> (Js_of_ocaml.Js.Unsafe.get a0 "b" : res)
                 (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#b))
-          ~a:((fun (type res) ->
-                 fun (type a0) ->
-                   fun (a0 : a0 Js_of_ocaml.Js.t) ->
-                     fun
-                       (_ :
-                         a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
-                       -> (Js_of_ocaml.Js.Unsafe.get a0 "a" : res))
+          ~a:(fun (type res) -> fun (type a0) ->
+                fun (a0 : a0 Js_of_ocaml.Js.t) ->
+                  fun (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
+                    -> (Js_of_ocaml.Js.Unsafe.get a0 "a" : res)
                 (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#a)) () in
       Test$Bar$component
   end
@@ -369,21 +353,15 @@ module Func(M:X_int) =
             Js_of_ocaml.Js.t)
         =
         make
-          ~b:((fun (type res) ->
-                 fun (type a0) ->
-                   fun (a0 : a0 Js_of_ocaml.Js.t) ->
-                     fun
-                       (_ :
-                         a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
-                       -> (Js_of_ocaml.Js.Unsafe.get a0 "b" : res))
+          ~b:(fun (type res) -> fun (type a0) ->
+                fun (a0 : a0 Js_of_ocaml.Js.t) ->
+                  fun (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
+                    -> (Js_of_ocaml.Js.Unsafe.get a0 "b" : res)
                 (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#b))
-          ~a:((fun (type res) ->
-                 fun (type a0) ->
-                   fun (a0 : a0 Js_of_ocaml.Js.t) ->
-                     fun
-                       (_ :
-                         a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
-                       -> (Js_of_ocaml.Js.Unsafe.get a0 "a" : res))
+          ~a:(fun (type res) -> fun (type a0) ->
+                fun (a0 : a0 Js_of_ocaml.Js.t) ->
+                  fun (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
+                    -> (Js_of_ocaml.Js.Unsafe.get a0 "a" : res)
                 (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#a)) () in
       Test$Func
   end
@@ -457,13 +435,12 @@ module Memo =
              < a: 'a Js_of_ocaml.Js.readonly_prop   >  Js_of_ocaml.Js.t)
            =
            make
-             ~a:((fun (type res) ->
-                    fun (type a0) ->
-                      fun (a0 : a0 Js_of_ocaml.Js.t) ->
-                        fun
-                          (_ :
-                            a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
-                          -> (Js_of_ocaml.Js.Unsafe.get a0 "a" : res))
+             ~a:(fun (type res) -> fun (type a0) ->
+                   fun (a0 : a0 Js_of_ocaml.Js.t) ->
+                     fun
+                       (_ :
+                         a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
+                       -> (Js_of_ocaml.Js.Unsafe.get a0 "a" : res)
                    (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#a)) in
          Test$Memo)
   end
@@ -503,13 +480,12 @@ module MemoCustomCompareProps =
              < a: 'a Js_of_ocaml.Js.readonly_prop   >  Js_of_ocaml.Js.t)
            =
            make
-             ~a:((fun (type res) ->
-                    fun (type a0) ->
-                      fun (a0 : a0 Js_of_ocaml.Js.t) ->
-                        fun
-                          (_ :
-                            a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
-                          -> (Js_of_ocaml.Js.Unsafe.get a0 "a" : res))
+             ~a:(fun (type res) -> fun (type a0) ->
+                   fun (a0 : a0 Js_of_ocaml.Js.t) ->
+                     fun
+                       (_ :
+                         a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
+                       -> (Js_of_ocaml.Js.Unsafe.get a0 "a" : res)
                    (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#a)) in
          Test$MemoCustomCompareProps)
         (fun prevPros -> fun nextProps -> false)


### PR DESCRIPTION
- Switch to ppxlib
- Drop the dependency on ocaml-migrate-parsetree
- Switch other libraries & tools to ppxlib-compatible versions